### PR TITLE
Fix for canvas crashes when dragging lights

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,35 +1,39 @@
 {
-	"id": "select-tool-everywhere",
-	"title": "Select tool everywhere",
-	"description": "Adds the select tool to all controls(measure templates, lighting and sound) and a patch for journal notes so the select tool works there too. This is a quick and dirty module. You can move multiple light/sounds/templates/journals with this. Thanks to Blitz#6797 the selection does show correctly.  This module checks if a select tool is there before adding it(also thanks to Blitz) and makes sure to only do anything if this module added the select tool, so it should be safe to use with other modules that add a select tool. This will probably be obsolete in the future.",
-	"version": "1.4.0",
-	"compatibility" :{
-		"minimum": 10,	
-		"verified": "10.286",
-		"maximum": 10	
-	},
-	"authors": [
-		{
-			"name": "KayelGee",
-			"url": "https://github.com/KayelGee",
-			"discord": "KayelGee#5241"
-		}
-	],
-	"scripts": [
-		"select-tool-everywhere.js"
-	],
-	"styles": [],
-	"packs": [],
-	"languages": [
-		{
-			"lang": "en",
-			"name": "English",
-			"path": "languages/en.json"
-		}
-	],
-	"socket": false,
-	"url": "https://github.com/KayelGee/select-tool-everywhere",
-  "manifest": "https://raw.githubusercontent.com/KayelGee/select-tool-everywhere/master/module.json",
-  "download": "https://github.com/KayelGee/select-tool-everywhere/releases/download/v1.4.0/v1.4.0.zip",
-  "readme": "https://github.com/KayelGee/select-tool-everywhere/blob/v1.4.0/README.md"
+    "id": "select-tool-everywhere",
+    "title": "Select tool everywhere",
+    "description": "Adds the select tool to all controls(measure templates, lighting and sound) and a patch for journal notes so the select tool works there too. This is a quick and dirty module. You can move multiple light/sounds/templates/journals with this. Thanks to Blitz#6797 the selection does show correctly.  This module checks if a select tool is there before adding it(also thanks to Blitz) and makes sure to only do anything if this module added the select tool, so it should be safe to use with other modules that add a select tool. This will probably be obsolete in the future.",
+    "version": "1.4.0",
+    "compatibility": {
+        "minimum": 10,
+        "verified": "10.286",
+        "maximum": 10
+    },
+    "authors": [
+        {
+            "name": "KayelGee",
+            "url": "https://github.com/KayelGee",
+            "discord": "KayelGee#5241"
+        }
+    ],
+    "scripts": ["select-tool-everywhere.js"],
+    "styles": [],
+    "dependencies": [
+        {
+            "name": "lib-wrapper",
+            "type": "module"
+        }
+    ],
+    "packs": [],
+    "languages": [
+        {
+            "lang": "en",
+            "name": "English",
+            "path": "languages/en.json"
+        }
+    ],
+    "socket": false,
+    "url": "https://github.com/KayelGee/select-tool-everywhere",
+    "manifest": "https://raw.githubusercontent.com/KayelGee/select-tool-everywhere/master/module.json",
+    "download": "https://github.com/KayelGee/select-tool-everywhere/releases/download/v1.4.0/v1.4.0.zip",
+    "readme": "https://github.com/KayelGee/select-tool-everywhere/blob/v1.4.0/README.md"
 }

--- a/module.json
+++ b/module.json
@@ -17,12 +17,6 @@
   ],
   "scripts": ["select-tool-everywhere.js"],
   "styles": [],
-  "dependencies": [
-    {
-      "name": "lib-wrapper",
-      "type": "module"
-    }
-  ],
   "packs": [],
   "languages": [
     {

--- a/module.json
+++ b/module.json
@@ -17,6 +17,12 @@
   ],
   "scripts": ["select-tool-everywhere.js"],
   "styles": [],
+  "dependencies": [
+    {
+      "name": "lib-wrapper",
+      "type": "module"
+    }
+  ],
   "packs": [],
   "languages": [
     {

--- a/module.json
+++ b/module.json
@@ -1,39 +1,39 @@
 {
-    "id": "select-tool-everywhere",
-    "title": "Select tool everywhere",
-    "description": "Adds the select tool to all controls(measure templates, lighting and sound) and a patch for journal notes so the select tool works there too. This is a quick and dirty module. You can move multiple light/sounds/templates/journals with this. Thanks to Blitz#6797 the selection does show correctly.  This module checks if a select tool is there before adding it(also thanks to Blitz) and makes sure to only do anything if this module added the select tool, so it should be safe to use with other modules that add a select tool. This will probably be obsolete in the future.",
-    "version": "1.4.0",
-    "compatibility": {
-        "minimum": 10,
-        "verified": "10.286",
-        "maximum": 10
-    },
-    "authors": [
-        {
-            "name": "KayelGee",
-            "url": "https://github.com/KayelGee",
-            "discord": "KayelGee#5241"
-        }
-    ],
-    "scripts": ["select-tool-everywhere.js"],
-    "styles": [],
-    "dependencies": [
-        {
-            "name": "lib-wrapper",
-            "type": "module"
-        }
-    ],
-    "packs": [],
-    "languages": [
-        {
-            "lang": "en",
-            "name": "English",
-            "path": "languages/en.json"
-        }
-    ],
-    "socket": false,
-    "url": "https://github.com/KayelGee/select-tool-everywhere",
-    "manifest": "https://raw.githubusercontent.com/KayelGee/select-tool-everywhere/master/module.json",
-    "download": "https://github.com/KayelGee/select-tool-everywhere/releases/download/v1.4.0/v1.4.0.zip",
-    "readme": "https://github.com/KayelGee/select-tool-everywhere/blob/v1.4.0/README.md"
+  "id": "select-tool-everywhere",
+  "title": "Select tool everywhere",
+  "description": "Adds the select tool to all controls(measure templates, lighting and sound) and a patch for journal notes so the select tool works there too. This is a quick and dirty module. You can move multiple light/sounds/templates/journals with this. Thanks to Blitz#6797 the selection does show correctly.  This module checks if a select tool is there before adding it(also thanks to Blitz) and makes sure to only do anything if this module added the select tool, so it should be safe to use with other modules that add a select tool. This will probably be obsolete in the future.",
+  "version": "1.4.0",
+  "compatibility": {
+    "minimum": 10,
+    "verified": "10.286",
+    "maximum": 10
+  },
+  "authors": [
+    {
+      "name": "KayelGee",
+      "url": "https://github.com/KayelGee",
+      "discord": "KayelGee#5241"
+    }
+  ],
+  "scripts": ["select-tool-everywhere.js"],
+  "styles": [],
+  "dependencies": [
+    {
+      "name": "lib-wrapper",
+      "type": "module"
+    }
+  ],
+  "packs": [],
+  "languages": [
+    {
+      "lang": "en",
+      "name": "English",
+      "path": "languages/en.json"
+    }
+  ],
+  "socket": false,
+  "url": "https://github.com/KayelGee/select-tool-everywhere",
+  "manifest": "https://raw.githubusercontent.com/KayelGee/select-tool-everywhere/master/module.json",
+  "download": "https://github.com/KayelGee/select-tool-everywhere/releases/download/v1.4.0/v1.4.0.zip",
+  "readme": "https://github.com/KayelGee/select-tool-everywhere/blob/v1.4.0/README.md"
 }

--- a/select-tool-everywhere.js
+++ b/select-tool-everywhere.js
@@ -47,13 +47,9 @@
       console.log("SelectToolEverywhere | Tools added.");
     }
 
-    static placeableSelected(placeable, selected) {
+    static placeableRefresh(placeable) {
       if (!window["select-tool-everywhere"].find((type) => type === placeable.layer.constructor.documentName)) return;
-      placeable.controlIcon.border.visible = selected;
-    }
-    static placeableHovered(placeable, hovered) {
-      if (!window["select-tool-everywhere"].find((type) => type === placeable.layer.constructor.documentName)) return;
-      if (placeable._controlled) {
+      if (placeable.controlled) {
         placeable.controlIcon.border.visible = true;
       }
     }
@@ -61,9 +57,8 @@
   window["select-tool-everywhere"] = [];
   Hooks.on("getSceneControlButtons", (controls) => SelectToolEverywhere._getControlButtons(controls));
   Hooks.on("canvasReady", () => SelectToolEverywhere.initialize());
-  for (const type of ["AmbientSound", "MeasuredTemplate"]) {
-    Hooks.on(`control${type}`, SelectToolEverywhere.placeableSelected);
-    Hooks.on(`hover${type}`, SelectToolEverywhere.placeableHovered);
+  for (const type of ["AmbientSound", "MeasuredTemplate", "AmbientLight"]) {
+    Hooks.on(`refresh${type}`, SelectToolEverywhere.placeableRefresh);
   }
   Hooks.once("init", () => {
     libWrapper.register(

--- a/select-tool-everywhere.js
+++ b/select-tool-everywhere.js
@@ -5,6 +5,7 @@
       canvas.getLayerByEmbeddedName("AmbientLight").options.controllableObjects = true;
       canvas.getLayerByEmbeddedName("AmbientSound").options.controllableObjects = true;
       canvas.getLayerByEmbeddedName("MeasuredTemplate").options.controllableObjects = true;
+      canvas.getLayerByEmbeddedName("Note").options.controllableObjects = true;
     }
 
     /**
@@ -22,8 +23,7 @@
             });
             added_tools.push("AmbientLight");
           }
-        }
-        if (controls[i].name === "sounds") {
+        } else if (controls[i].name === "sounds") {
           if (!controls[i].tools.find((tool) => tool.name === "select")) {
             controls[i].tools.unshift({
               name: "select",
@@ -48,18 +48,25 @@
     }
 
     static placeableRefresh(placeable) {
-      if (!window["select-tool-everywhere"].find((type) => type === placeable.layer.constructor.documentName)) return;
-      if (placeable.controlled) {
-        placeable.controlIcon.border.visible = true;
-      }
+      if (placeable.controlled) placeable.controlIcon.border.visible = true;
     }
   }
   window["select-tool-everywhere"] = [];
   Hooks.on("getSceneControlButtons", (controls) => SelectToolEverywhere._getControlButtons(controls));
   Hooks.on("canvasReady", () => SelectToolEverywhere.initialize());
-  for (const type of ["AmbientSound", "MeasuredTemplate", "AmbientLight"]) {
+  for (const type of ["AmbientSound", "MeasuredTemplate", "AmbientLight", "Note"]) {
     Hooks.on(`refresh${type}`, SelectToolEverywhere.placeableRefresh);
   }
+
+  // For notes the refresh hook is called while ControlIcon is still loading its texture (see ControlIcon.draw())
+  // Once the texture is loaded border visibility will be reset to false undoing our change in SelectToolEverywhere.placeableRefresh
+  // Instead delay here to account for this
+  Hooks.on("drawNote", (note) => {
+    setTimeout(() => {
+      SelectToolEverywhere.placeableRefresh(note);
+    }, 10);
+  });
+
   Hooks.once("init", () => {
     libWrapper.register(
       "select-tool-everywhere",

--- a/select-tool-everywhere.js
+++ b/select-tool-everywhere.js
@@ -67,17 +67,17 @@
     }, 10);
   });
 
-  // Slightly modified 'AmbientLight._onDragLeftCancel' to defer source updates instead of applying them immediately
-  function lightDragLeftCancel(event) {
-    Object.getPrototypeOf(AmbientLight).prototype._onDragLeftCancel.call(this, event);
-    this.updateSource({ defer: true });
-  }
-
-  // To avoid race conditions between multiple light _onDragLeftCancel calls we'll patch the cached function within
-  // MouseInteractionManager instance to defer source updates
-  Hooks.on("controlAmbientLight", (light) => {
-    if (light.mouseInteractionManager?.callbacks) {
-      light.mouseInteractionManager.callbacks.dragLeftCancel = lightDragLeftCancel.bind(light);
-    }
+  Hooks.once("init", () => {
+    // To avoid race conditions between multiple AmbientLight _onDragLeftCancel calls we'll defer the
+    // canvas.perception update within 'updateSource' via a 'defer' argument
+    libWrapper.register(
+      "select-tool-everywhere",
+      "AmbientLight.prototype._onDragLeftCancel",
+      function (...args) {
+        Object.getPrototypeOf(AmbientLight).prototype._onDragLeftCancel.apply(this, args);
+        this.updateSource({ defer: true });
+      },
+      "OVERRIDE"
+    );
   });
 })();

--- a/select-tool-everywhere.js
+++ b/select-tool-everywhere.js
@@ -2,7 +2,9 @@
 	class SelectToolEverywhere {
 		static initialize(){
 			//Patch so select tool works for Light and Sound
-			//canvas.getLayerByEmbeddedName("AmbientLight").options.controllableObjects = true;
+            if (typeof libWrapper === "function") {
+                canvas.getLayerByEmbeddedName("AmbientLight").options.controllableObjects = true;
+            }
 			canvas.getLayerByEmbeddedName("AmbientSound").options.controllableObjects = true;
 			canvas.getLayerByEmbeddedName("MeasuredTemplate").options.controllableObjects = true;
 		}
@@ -13,16 +15,18 @@
 		static _getControlButtons(controls){
 			let added_tools=[];
 			for (let i = 0; i < controls.length; i++) {
-				// if(controls[i].name === "lighting"){
-				// 	if (!controls[i].tools.find(tool => tool.name === "select")) {
-				// 		controls[i].tools.unshift({
-				// 			name: "select",
-				// 			title: "CONTROLS.LightSelect",
-				// 			icon: "fas fa-expand"
-				// 		});
-				// 		added_tools.push("AmbientLight");
-				// 	}
-				// }
+                if (typeof libWrapper === "function") {
+                    if(controls[i].name === "lighting"){
+                        if (!controls[i].tools.find(tool => tool.name === "select")) {
+                            controls[i].tools.unshift({
+                                name: "select",
+                                title: "CONTROLS.LightSelect",
+                                icon: "fas fa-expand"
+                            });
+                            added_tools.push("AmbientLight");
+                        }
+                    }
+                }
 				if(controls[i].name === "sounds"){
 					if (!controls[i].tools.find(tool => tool.name === "select")) {
 						controls[i].tools.unshift({
@@ -67,4 +71,14 @@
 		Hooks.on(`control${type}`, SelectToolEverywhere.placeableSelected);
 		Hooks.on(`hover${type}`, SelectToolEverywhere.placeableHovered);
 	}
+    Hooks.once("init", () => {
+        if (typeof libWrapper === "function") {
+            libWrapper.register("select-tool-everywhere", "AmbientLight.prototype._onDragLeftCancel",
+                function (...args) {
+                    Object.getPrototypeOf(AmbientLight).prototype._onDragLeftCancel.apply(this, ...args);
+                    this.updateSource({ defer: true });
+                }, "OVERRIDE"
+            );
+        }
+    });
 })();

--- a/select-tool-everywhere.js
+++ b/select-tool-everywhere.js
@@ -2,9 +2,7 @@
 	class SelectToolEverywhere {
 		static initialize(){
 			//Patch so select tool works for Light and Sound
-            if (typeof libWrapper === "function") {
-                canvas.getLayerByEmbeddedName("AmbientLight").options.controllableObjects = true;
-            }
+			canvas.getLayerByEmbeddedName("AmbientLight").options.controllableObjects = true;
 			canvas.getLayerByEmbeddedName("AmbientSound").options.controllableObjects = true;
 			canvas.getLayerByEmbeddedName("MeasuredTemplate").options.controllableObjects = true;
 		}
@@ -15,18 +13,16 @@
 		static _getControlButtons(controls){
 			let added_tools=[];
 			for (let i = 0; i < controls.length; i++) {
-                if (typeof libWrapper === "function") {
-                    if(controls[i].name === "lighting"){
-                        if (!controls[i].tools.find(tool => tool.name === "select")) {
-                            controls[i].tools.unshift({
-                                name: "select",
-                                title: "CONTROLS.LightSelect",
-                                icon: "fas fa-expand"
-                            });
-                            added_tools.push("AmbientLight");
-                        }
-                    }
-                }
+				if(controls[i].name === "lighting"){
+					if (!controls[i].tools.find(tool => tool.name === "select")) {
+						controls[i].tools.unshift({
+							name: "select",
+							title: "CONTROLS.LightSelect",
+							icon: "fas fa-expand"
+						});
+						added_tools.push("AmbientLight");
+					}
+				}
 				if(controls[i].name === "sounds"){
 					if (!controls[i].tools.find(tool => tool.name === "select")) {
 						controls[i].tools.unshift({
@@ -72,13 +68,11 @@
 		Hooks.on(`hover${type}`, SelectToolEverywhere.placeableHovered);
 	}
     Hooks.once("init", () => {
-        if (typeof libWrapper === "function") {
-            libWrapper.register("select-tool-everywhere", "AmbientLight.prototype._onDragLeftCancel",
-                function (...args) {
-                    Object.getPrototypeOf(AmbientLight).prototype._onDragLeftCancel.apply(this, ...args);
-                    this.updateSource({ defer: true });
-                }, "OVERRIDE"
-            );
-        }
+		libWrapper.register("select-tool-everywhere", "AmbientLight.prototype._onDragLeftCancel",
+			function (...args) {
+				Object.getPrototypeOf(AmbientLight).prototype._onDragLeftCancel.apply(this, ...args);
+				this.updateSource({ defer: true });
+			}, "OVERRIDE"
+		);
     });
 })();

--- a/select-tool-everywhere.js
+++ b/select-tool-everywhere.js
@@ -1,78 +1,79 @@
 (async () => {
-	class SelectToolEverywhere {
-		static initialize(){
-			//Patch so select tool works for Light and Sound
-			canvas.getLayerByEmbeddedName("AmbientLight").options.controllableObjects = true;
-			canvas.getLayerByEmbeddedName("AmbientSound").options.controllableObjects = true;
-			canvas.getLayerByEmbeddedName("MeasuredTemplate").options.controllableObjects = true;
-		}
+  class SelectToolEverywhere {
+    static initialize() {
+      //Patch so select tool works for Light and Sound
+      canvas.getLayerByEmbeddedName("AmbientLight").options.controllableObjects = true;
+      canvas.getLayerByEmbeddedName("AmbientSound").options.controllableObjects = true;
+      canvas.getLayerByEmbeddedName("MeasuredTemplate").options.controllableObjects = true;
+    }
 
-		/**
-		 * Hook into the toolbar and add buttons 
-		 */
-		static _getControlButtons(controls){
-			let added_tools=[];
-			for (let i = 0; i < controls.length; i++) {
-				if(controls[i].name === "lighting"){
-					if (!controls[i].tools.find(tool => tool.name === "select")) {
-						controls[i].tools.unshift({
-							name: "select",
-							title: "CONTROLS.LightSelect",
-							icon: "fas fa-expand"
-						});
-						added_tools.push("AmbientLight");
-					}
-				}
-				if(controls[i].name === "sounds"){
-					if (!controls[i].tools.find(tool => tool.name === "select")) {
-						controls[i].tools.unshift({
-							name: "select",
-							title: "CONTROLS.SoundSelect",
-							icon: "fas fa-expand"
-						});
-						added_tools.push("AmbientSound");
-					}
-				}
-				else if(controls[i].name === "measure"){
-					if (!controls[i].tools.find(tool => tool.name === "select")) {
-						controls[i].tools.unshift({
-							name: "select",
-							title: "CONTROLS.TemplateSelect",
-							icon: "fas fa-expand"
-						});
-						added_tools.push("MeasuredTemplate");
-					}
-				}
-			}
-			window['select-tool-everywhere']=added_tools;
-			console.log("SelectToolEverywhere | Tools added.");
-		}
+    /**
+     * Hook into the toolbar and add buttons
+     */
+    static _getControlButtons(controls) {
+      let added_tools = [];
+      for (let i = 0; i < controls.length; i++) {
+        if (controls[i].name === "lighting") {
+          if (!controls[i].tools.find((tool) => tool.name === "select")) {
+            controls[i].tools.unshift({
+              name: "select",
+              title: "CONTROLS.LightSelect",
+              icon: "fas fa-expand",
+            });
+            added_tools.push("AmbientLight");
+          }
+        }
+        if (controls[i].name === "sounds") {
+          if (!controls[i].tools.find((tool) => tool.name === "select")) {
+            controls[i].tools.unshift({
+              name: "select",
+              title: "CONTROLS.SoundSelect",
+              icon: "fas fa-expand",
+            });
+            added_tools.push("AmbientSound");
+          }
+        } else if (controls[i].name === "measure") {
+          if (!controls[i].tools.find((tool) => tool.name === "select")) {
+            controls[i].tools.unshift({
+              name: "select",
+              title: "CONTROLS.TemplateSelect",
+              icon: "fas fa-expand",
+            });
+            added_tools.push("MeasuredTemplate");
+          }
+        }
+      }
+      window["select-tool-everywhere"] = added_tools;
+      console.log("SelectToolEverywhere | Tools added.");
+    }
 
-		static placeableSelected(placeable, selected){
-			if(!window['select-tool-everywhere'].find(type => type === placeable.layer.constructor.documentName)) return;
-            placeable.controlIcon.border.visible = selected;
-		}
-		static placeableHovered(placeable, hovered){
-			if(!window['select-tool-everywhere'].find(type => type === placeable.layer.constructor.documentName)) return;
-			if(placeable._controlled){
-				placeable.controlIcon.border.visible = true;
-			}
-		}
-
-	}
-	window['select-tool-everywhere']=[];
-	Hooks.on('getSceneControlButtons', (controls) => SelectToolEverywhere._getControlButtons(controls));
-	Hooks.on('canvasReady', () => SelectToolEverywhere.initialize());
-	for (const type of ["AmbientSound", "MeasuredTemplate"]) {
-		Hooks.on(`control${type}`, SelectToolEverywhere.placeableSelected);
-		Hooks.on(`hover${type}`, SelectToolEverywhere.placeableHovered);
-	}
-    Hooks.once("init", () => {
-		libWrapper.register("select-tool-everywhere", "AmbientLight.prototype._onDragLeftCancel",
-			function (...args) {
-				Object.getPrototypeOf(AmbientLight).prototype._onDragLeftCancel.apply(this, ...args);
-				this.updateSource({ defer: true });
-			}, "OVERRIDE"
-		);
-    });
+    static placeableSelected(placeable, selected) {
+      if (!window["select-tool-everywhere"].find((type) => type === placeable.layer.constructor.documentName)) return;
+      placeable.controlIcon.border.visible = selected;
+    }
+    static placeableHovered(placeable, hovered) {
+      if (!window["select-tool-everywhere"].find((type) => type === placeable.layer.constructor.documentName)) return;
+      if (placeable._controlled) {
+        placeable.controlIcon.border.visible = true;
+      }
+    }
+  }
+  window["select-tool-everywhere"] = [];
+  Hooks.on("getSceneControlButtons", (controls) => SelectToolEverywhere._getControlButtons(controls));
+  Hooks.on("canvasReady", () => SelectToolEverywhere.initialize());
+  for (const type of ["AmbientSound", "MeasuredTemplate"]) {
+    Hooks.on(`control${type}`, SelectToolEverywhere.placeableSelected);
+    Hooks.on(`hover${type}`, SelectToolEverywhere.placeableHovered);
+  }
+  Hooks.once("init", () => {
+    libWrapper.register(
+      "select-tool-everywhere",
+      "AmbientLight.prototype._onDragLeftCancel",
+      function (...args) {
+        Object.getPrototypeOf(AmbientLight).prototype._onDragLeftCancel.apply(this, args);
+        this.updateSource({ defer: true });
+      },
+      "OVERRIDE"
+    );
+  });
 })();


### PR DESCRIPTION
Fix for: https://github.com/KayelGee/select-tool-everywhere/issues/5

Light controls are re-enabled if ``libWrapper`` is active. Patches ``AmbientLight._onDragLeftCancel`` to defer updates and prevent race conditions when dragging multiple lights.